### PR TITLE
Support for ruby 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-*
 .bundle/
 Gemfile.lock
 coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 env:
   - 'RAILS_VERSION="5.1" AMS_VERSION="0.10.7"'
   - 'RAILS_VERSION="5.2" AMS_VERSION="0.10.12"'
+  - 'RAILS_VERSION="6.1" AMS_VERSION="0.10.13"'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gemspec
 
 gem 'rake', '< 11.0'
 
-rails_version = ENV['RAILS_VERSION'] || '5.2'
+rails_version = ENV.fetch('RAILS_VERSION', '5.2')
 if rails_version == 'master'
   gem 'rails', github: 'rails/rails'
 else

--- a/fun_with_json_api.gemspec
+++ b/fun_with_json_api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.1'
   s.add_dependency 'active_model_serializers', '>= 0.10.0'
 
-  s.add_development_dependency 'sqlite3', '~> 1.3.6'
+  s.add_development_dependency 'sqlite3', '~> 1.4'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'faker'
   s.add_development_dependency 'rubocop', '~> 0.38.0'

--- a/lib/fun_with_json_api/find_collection_from_document.rb
+++ b/lib/fun_with_json_api/find_collection_from_document.rb
@@ -3,8 +3,8 @@ require 'fun_with_json_api/schema_validators/check_collection_has_all_members'
 
 module FunWithJsonApi
   class FindCollectionFromDocument
-    def self.find(*args)
-      new(*args).find
+    def self.find(...)
+      new(...).find
     end
 
     private_class_method :new

--- a/lib/fun_with_json_api/find_resource_from_document.rb
+++ b/lib/fun_with_json_api/find_resource_from_document.rb
@@ -1,7 +1,7 @@
 module FunWithJsonApi
   class FindResourceFromDocument
-    def self.find(*args)
-      new(*args).find
+    def self.find(...)
+      new(...).find
     end
 
     private_class_method :new

--- a/lib/fun_with_json_api/schema_validators/check_collection_has_all_members.rb
+++ b/lib/fun_with_json_api/schema_validators/check_collection_has_all_members.rb
@@ -3,8 +3,8 @@ require 'fun_with_json_api/exception'
 module FunWithJsonApi
   module SchemaValidators
     class CheckCollectionHasAllMembers
-      def self.call(*args)
-        new(*args).call
+      def self.call(...)
+        new(...).call
       end
 
       attr_reader :collection

--- a/lib/fun_with_json_api/schema_validators/check_collection_is_authorized.rb
+++ b/lib/fun_with_json_api/schema_validators/check_collection_is_authorized.rb
@@ -3,8 +3,8 @@ require 'fun_with_json_api/exception'
 module FunWithJsonApi
   module SchemaValidators
     class CheckCollectionIsAuthorised
-      def self.call(*args)
-        new(*args).call
+      def self.call(...)
+        new(...).call
       end
 
       attr_reader :collection

--- a/lib/fun_with_json_api/schema_validators/check_relationship_names.rb
+++ b/lib/fun_with_json_api/schema_validators/check_relationship_names.rb
@@ -2,8 +2,8 @@ module FunWithJsonApi
   module SchemaValidators
     # Ensures all provided relationship names are known
     class CheckRelationshipNames
-      def self.call(*args)
-        new(*args).call
+      def self.call(...)
+        new(...).call
       end
 
       attr_reader :document

--- a/lib/fun_with_json_api/schema_validators/check_resource_is_authorized.rb
+++ b/lib/fun_with_json_api/schema_validators/check_resource_is_authorized.rb
@@ -3,8 +3,8 @@ require 'fun_with_json_api/exception'
 module FunWithJsonApi
   module SchemaValidators
     class CheckResourceIsAuthorised
-      def self.call(*args)
-        new(*args).call
+      def self.call(...)
+        new(...).call
       end
 
       attr_reader :resource

--- a/lib/fun_with_json_api/version.rb
+++ b/lib/fun_with_json_api/version.rb
@@ -1,3 +1,3 @@
 module FunWithJsonApi
-  VERSION = '0.0.13'.freeze
+  VERSION = '0.0.14'.freeze
 end

--- a/spec/fixtures/active_record.rb
+++ b/spec/fixtures/active_record.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define do
     t.text :contents
     t.references :author
     t.references :post
-    t.timestamp null: false
+    t.timestamps null: false
   end
 end
 

--- a/spec/fun_with_json_api/controller_methods_spec.rb
+++ b/spec/fun_with_json_api/controller_methods_spec.rb
@@ -37,7 +37,7 @@ describe FunWithJsonApi::ControllerMethods, type: :controller do
         it 'returns a json api error status' do
           get :index
           expect(response.status).to eq 403
-          expect(response.content_type).to eq 'application/vnd.api+json'
+          expect(response.content_type).to include('application/vnd.api+json')
         end
 
         it 'renders the exception payload as a json api errors response' do
@@ -77,7 +77,7 @@ describe FunWithJsonApi::ControllerMethods, type: :controller do
         it 'returns a json api error status' do
           get :index
           expect(response.status).to eq 403
-          expect(response.content_type).to eq 'application/vnd.api+json'
+          expect(response.content_type).to include('application/vnd.api+json')
         end
 
         it 'renders all exception payload items' do
@@ -108,7 +108,7 @@ describe FunWithJsonApi::ControllerMethods, type: :controller do
         it 'returns a json api error status' do
           get :index
           expect(response.status).to eq 422
-          expect(response.content_type).to eq 'application/vnd.api+json'
+          expect(response.content_type).to include('application/vnd.api+json')
         end
 
         it 'only renders the non-nil params' do

--- a/spec/fun_with_json_api/railtie_spec.rb
+++ b/spec/fun_with_json_api/railtie_spec.rb
@@ -50,7 +50,7 @@ describe FunWithJsonApi::Railtie do
 
       it 'renders out the hash as a json_api response' do
         get :index
-        expect(response.content_type).to eq 'application/vnd.api+json'
+        expect(response.content_type).to include('application/vnd.api+json')
         expect(JSON.parse(response.body)).to eq(
           'data' => { 'id' => '42', 'type' => 'foobar' }
         )
@@ -66,7 +66,7 @@ describe FunWithJsonApi::Railtie do
 
       it 'renders the resource as a json api document' do
         get :index
-        expect(response.content_type).to eq 'application/vnd.api+json'
+        expect(response.content_type).to include('application/vnd.api+json')
         expect(JSON.parse(response.body)).to eq(
           'data' => {
             'id' => '42',


### PR DESCRIPTION
Now supporting ruby 3 - updated all wrapping methods to use `...` notation to support *args, **kwargs, &block handoffs